### PR TITLE
Update Vercel configuration to remove conflicting 'routes' setting.

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,8 +2,5 @@
   "version": 2,
   "rewrites": [
     { "source": "/", "destination": "/api/index" }
-  ],
-  "routes": [
-    { "src": "/api/index", "dest": "server.js" }
   ]
 }


### PR DESCRIPTION
The 'routes' setting is incompatible with 'rewrites' and caused deployment failures. This commit removes the 'routes' setting from vercel.json to resolve the issue.