### PR TITLE
Add @types/react as a dev dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
+    "@types/react": "^18.0.0",
     "eslint": "^8.0.0",
     "eslint-config-next": "^14.0.0",
     "supertest": "^6.3.3",


### PR DESCRIPTION
This commit adds @types/react to the devDependencies in package.json, using the same version as the existing react dependency. This provides type definitions for React, improving the development experience.