### PR TITLE
Implement filtering quotes by author

### DIFF
--- a/pages/api/quote.ts
+++ b/pages/api/quote.ts
@@ -14,8 +14,20 @@ export default function handler(req: NextApiRequest, res: NextApiResponse<Quote>
     { quote: "It is during our darkest moments that we must focus to see the light.", author: "Aristotle" },
   ];
 
-  const randomIndex = Math.floor(Math.random() * quotes.length);
-  const selectedQuote: Quote = quotes[randomIndex];
+  const { author } = req.query;
+
+  let selectedQuote: Quote;
+  if (author) {
+    const filteredQuotes = quotes.filter(quote => quote.author === author);
+    if (filteredQuotes.length > 0) {
+      selectedQuote = filteredQuotes[Math.floor(Math.random() * filteredQuotes.length)];
+    } else {
+      // Return a random quote if the author is not found.
+      selectedQuote = quotes[Math.floor(Math.random() * quotes.length)];
+    }
+  } else {
+    selectedQuote = quotes[Math.floor(Math.random() * quotes.length)];
+  }
 
   res.status(200).json(selectedQuote);
 }


### PR DESCRIPTION
The API endpoint  now supports an optional  query parameter. If provided, the endpoint will return a quote by the specified author. If no author is found or the parameter is missing, a random quote will be returned. This change aligns the API behavior with the existing integration tests.