### PR TITLE
Fix: Update import for createHandler in integration tests

### DIFF
--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,4 +1,4 @@
-import { createHandler } from 'next-test-api-route-handler';
+import createHandler from 'next-test-api-route-handler';
 import handler from '../pages/api/quote'; // Import your API route
 
 describe('Integration Tests', () => {


### PR DESCRIPTION
The import statement for  in  was incorrect, causing a TypeScript error. This commit updates the import to use the default export from , resolving the issue.