### PR TITLE
Update eslint and supertest to address deprecation warnings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
-    "eslint": "^8.0.0",
+    "eslint": "^8.57.0",
     "eslint-config-next": "^14.0.0",
-    "supertest": "^6.3.3",
+    "supertest": "^6.3.4",
     "jest": "^29.7.0",
     "ts-jest": "^29.0.0",
     "next-test-api-route-handler": "latest"


### PR DESCRIPTION
This commit updates eslint and supertest to their latest versions to resolve npm deprecation warnings during installation. Other outdated packages were transitive dependencies and are assumed to be updated as necessary.