### PR TITLE
Restrict quote API to only handle GET requests.

### DIFF
--- a/pages/api/quote.ts
+++ b/pages/api/quote.ts
@@ -6,28 +6,32 @@ type Quote = {
 import { NextApiRequest, NextApiResponse } from 'next';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse<Quote | { error: string }>) {
-  const quotes: Quote[] = [
-    { quote: "The only way to do great work is to love what you do.", author: "Steve Jobs" },
-    { quote: "Strive not to be a success, but rather to be of value.", author: "Albert Einstein" },
-    { quote: "The mind is everything. What you think you become.", author: "Buddha" },
-    { quote: "The best and most beautiful things in the world cannot be seen or even touched - they must be felt with the heart.", author: "Helen Keller" },
-    { quote: "It is during our darkest moments that we must focus to see the light.", author: "Aristotle" },
-  ];
+  if (req.method === 'GET') {
+    const quotes: Quote[] = [
+      { quote: "The only way to do great work is to love what you do.", author: "Steve Jobs" },
+      { quote: "Strive not to be a success, but rather to be of value.", author: "Albert Einstein" },
+      { quote: "The mind is everything. What you think you become.", author: "Buddha" },
+      { quote: "The best and most beautiful things in the world cannot be seen or even touched - they must be felt with the heart.", author: "Helen Keller" },
+      { quote: "It is during our darkest moments that we must focus to see the light.", author: "Aristotle" },
+    ];
 
-  if (req.query.author) {
-    const author = req.query.author as string;
-    const filteredQuotes = quotes.filter(quote => quote.author === author);
+    if (req.query.author) {
+      const author = req.query.author as string;
+      const filteredQuotes = quotes.filter(quote => quote.author === author);
 
-    if (filteredQuotes.length === 0) {
-      return res.status(404).json({ error: `No quotes found for author: ${author}` });
+      if (filteredQuotes.length === 0) {
+        return res.status(404).json({ error: `No quotes found for author: ${author}` });
+      }
+
+      const randomIndex = Math.floor(Math.random() * filteredQuotes.length);
+      const selectedQuote: Quote = filteredQuotes[randomIndex];
+      return res.status(200).json(selectedQuote);
+    } else {
+      const randomIndex = Math.floor(Math.random() * quotes.length);
+      const selectedQuote: Quote = quotes[randomIndex];
+      return res.status(200).json(selectedQuote);
     }
-
-    const randomIndex = Math.floor(Math.random() * filteredQuotes.length);
-    const selectedQuote: Quote = filteredQuotes[randomIndex];
-    return res.status(200).json(selectedQuote);
   } else {
-    const randomIndex = Math.floor(Math.random() * quotes.length);
-    const selectedQuote: Quote = quotes[randomIndex];
-    return res.status(200).json(selectedQuote);
+    return res.status(405).json({ error: 'Method Not Allowed' });
   }
 }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -48,4 +48,17 @@ describe('Integration Tests', () => {
     const data = res._getJSONData();
     expect(data).toHaveProperty('error', `No quotes found for author: ${author}`);
   });
+
+  it('should return 405 for non-GET requests', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      url: '/api/quote',
+    });
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(405);
+    const data = res._getJSONData();
+    expect(data).toHaveProperty('error', 'Method Not Allowed');
+  });
 });


### PR DESCRIPTION
This change modifies the quote API endpoint to only respond to GET requests. Any other request method (e.g., POST) will now result in a 405 Method Not Allowed error. An integration test has been added to verify this behavior.