### PR TITLE
Setup Playwright for end-to-end testing

### DIFF
--- a/.github/workflows/pr-main-checker.yml
+++ b/.github/workflows/pr-main-checker.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Install dependencies
         run: npm install
       - name: Run Integration tests
-        run: npm test-integration
+        run: npm run test-integration
       - name: Run E2E tests
         run: npm run test-e2e

--- a/.github/workflows/pr-main-checker.yml
+++ b/.github/workflows/pr-main-checker.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: '20'
       - name: Install dependencies
         run: npm install
-      - name: Run tests
-        run: npm test
+      - name: Run Integration tests
+        run: npm test-integration
       - name: Run E2E tests
         run: npm run test-e2e

--- a/.github/workflows/pr-main-checker.yml
+++ b/.github/workflows/pr-main-checker.yml
@@ -18,3 +18,5 @@ jobs:
         run: npm install
       - name: Run tests
         run: npm test
+      - name: Run E2E tests
+        run: npm run test-e2e

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest",
+    "test-integration": "jest --testPathPattern=test/integration",
     "test-e2e": "npx playwright test"
   },
   "dependencies": {
@@ -24,6 +24,7 @@
     "ts-jest": "^29.0.0",
     "@types/jest": "^29.5.12",
     "node-mocks-http": "^1.15.0",
-    "playwright": "^1.44.0"
+    "playwright": "^1.44.0",
+    "@playwright/test": "^1.51.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "jest",
+    "test-e2e": "npx playwright test"
   },
   "dependencies": {
     "next": "^14.0.0",
@@ -22,6 +23,7 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.0.0",
     "@types/jest": "^29.5.12",
-    "node-mocks-http": "^1.15.0"
+    "node-mocks-http": "^1.15.0",
+    "playwright": "^1.44.0"
   }
 }

--- a/test/playwright/example.spec.ts
+++ b/test/playwright/example.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+  await page.goto('/');
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/Random Quote/);
+});
+
+test('get started link', async ({ page }) => {
+  await page.goto('/');
+
+  // Expect an element with the text 'Get started' to be visible.
+  await expect(page.locator('h1')).toBeVisible();
+});

--- a/test/playwright/playwright.config.ts
+++ b/test/playwright/playwright.config.ts
@@ -1,0 +1,77 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});


### PR DESCRIPTION
This commit sets up Playwright for end-to-end testing in the project. It includes:

- Adding Playwright as a development dependency.
- Creating a Playwright configuration file () with basic settings.
- Creating an example Playwright test file () that navigates to the homepage and checks for a specific element.
