### PR TITLE
Fix: Extend global object type to include requestCounts for rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "start": "next start",
     "lint": "eslint .",
     "lint-fix": "eslint . --fix",
-    "test-unit": "jest --testPathPattern=tests/unit --detectOpenHandles",
-    "test-integration": "jest --testPathPattern=tests/integration --detectOpenHandles",
+    "test-unit": "jest --testPathPattern=tests/unit --detectOpenHandles --no-cache ",
+    "test-integration": "jest --testPathPattern=tests/integration --detectOpenHandles --no-cache ",
     "test-e2e": "npx playwright test"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "start": "next start",
     "lint": "eslint .",
     "lint-fix": "eslint . --fix",
-    "test-unit": "jest --testPathPattern=tests/unit",
-    "test-integration": "jest --testPathPattern=tests/integration",
+    "test-unit": "jest --testPathPattern=tests/unit --detectOpenHandles",
+    "test-integration": "jest --testPathPattern=tests/integration --detectOpenHandles",
     "test-e2e": "npx playwright test"
   },
   "dependencies": {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -2,4 +2,5 @@ export {};
 
 declare global {
   var requestCounts: Map<string, number[]> | undefined;
+  var cleanupInterval: NodeJS.Timeout;
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,5 @@
+export {};
+
+declare global {
+  var requestCounts: Map<string, number[]> | undefined;
+}

--- a/tests/integration/integration.test.ts
+++ b/tests/integration/integration.test.ts
@@ -3,7 +3,7 @@ import handler from '../../pages/api/quote'; // Import your API route
 
 describe('Integration Tests', () => {
 
-  after(() => {
+  afterAll(() => {
     clearInterval(global.cleanupInterval);
   });
   

--- a/tests/integration/integration.test.ts
+++ b/tests/integration/integration.test.ts
@@ -2,6 +2,11 @@ import { createMocks } from 'node-mocks-http'
 import handler from '../../pages/api/quote'; // Import your API route
 
 describe('Integration Tests', () => {
+
+  after(() => {
+    clearInterval(global.cleanupInterval);
+  });
+  
   it('should return a quote', async () => {
     const { req, res } = createMocks({
       method: 'GET',


### PR DESCRIPTION
This commit adds a  file to extend the global object's type definition, resolving the TypeScript error related to the  property used for rate limiting in the  API route.