### PR TITLE
Add copy to clipboard functionality to quotes.

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { styled } from '@mui/material/styles';
 import { Box, IconButton } from '@mui/material';
-import FileCopyIcon from '@mui/icons-material/FileCopy';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import RotateRightIcon from '@mui/icons-material/RotateRight';
 import Head from 'next/head';
 import ThemeProvider from '../src/components/ThemeProvider';
@@ -158,7 +158,7 @@ const HomePage = () => {
                   onClick={() => copyToClipboard(`"${quote.quote}" - ${quote.author}`)}
                   data-testid="copy-quote-btn"
                 >
-                  <FileCopyIcon fontSize="small" />
+                  <ContentCopyIcon fontSize="small" />
                 </IconButton>
                 <QuoteText id="quote">&ldquo;{quote.quote}&rdquo;</QuoteText>
               </Box>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -117,7 +117,7 @@ const HomePage = () => {
               margin: '8px'
             }}
             onClick={() => copyToClipboard(`${quote.quote} - ${quote.author}`)}
-            dataTestId="copy-quote-btn"
+            data-testid="copy-quote-btn"
           >
             <FileCopyIcon />
           </IconButton>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -109,24 +109,26 @@ const HomePage = () => {
       </Head>
       <MainContainer>
         <QuoteContainer>
-          <IconButton
-            sx={{
-              position: 'absolute',
-              top: 8,
-              right: 8,
-              margin: '8px'
-            }}
-            onClick={() => copyToClipboard(`${quote.quote} - ${quote.author}`)}
-            data-testid="copy-quote-btn"
-          >
-            <FileCopyIcon />
           </IconButton>
           {quote.error ? (
             <ErrorMessage id="error">{quote.error}</ErrorMessage>
           ) : (
             <>
               <Tagline>Your daily dose of inspiration.</Tagline>
-              <QuoteText id="quote">&ldquo;{quote.quote}&rdquo;</QuoteText>
+              <div>
+                <QuoteText id="quote">&ldquo;{quote.quote}&rdquo;</QuoteText>
+                <IconButton
+                  sx={{
+                    position: 'absolute',
+                    top: 8,
+                    right: 8,
+                    margin: '8px'
+                  }}
+                  onClick={() => copyToClipboard(`${quote.quote} - ${quote.author}`)}
+                  data-testid="copy-quote-btn"
+                >
+                  <FileCopyIcon />
+              </div>
               <AuthorText id="author">- {quote.author}</AuthorText>
               <NewQuoteButton onClick={() => fetchNewQuote()} disabled={loading}>
                 New Quote

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -122,9 +122,9 @@ const HomePage = () => {
                   size="small"
                   sx={{
                     position: 'absolute',
-                    top: 8,
-                    right: '-8px',
-                    margin: '8px'
+                    top: '-8px',
+                    right: '-20px',
+                    margin: 0
                   }}
                   onClick={() => copyToClipboard(`${quote.quote} - ${quote.author}`)}
                   data-testid="copy-quote-btn"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -116,7 +116,7 @@ const HomePage = () => {
               right: 8,
               margin: '8px'
             }}
-            onClick={() => copyToClipboard(quote.quote)}
+            onClick={() => copyToClipboard(`${quote.quote} - ${quote.author}`)}
           >
             <FileCopyIcon />
           </IconButton>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { styled } from '@mui/material/styles';
+import { Box, IconButton } from '@mui/material';
+import FileCopyIcon from '@mui/icons-material/FileCopy';
 import Head from 'next/head';
 import Loading from '../src/components/Loading';
 import ThemeProvider from '../src/components/ThemeProvider';
@@ -21,12 +23,13 @@ const MainContainer = styled("div")(() => ({
   color: 'secondary.contrastText',
 }));
 
-const QuoteContainer = styled("div")(() => ({
+const QuoteContainer = styled(Box)(() => ({
+  position: 'relative',
   padding: '16px',
   maxWidth: '600px',
   textAlign: 'center',
   backgroundColor: 'background.paper',
-  color: 'text.primary'
+  color: 'text.primary',
 }));
 
 const ErrorMessage = styled("div")(() => ({
@@ -106,6 +109,17 @@ const HomePage = () => {
       </Head>
       <MainContainer>
         <QuoteContainer>
+          <IconButton
+            sx={{
+              position: 'absolute',
+              top: 8,
+              right: 8,
+              margin: '8px'
+            }}
+            onClick={() => copyToClipboard(quote.quote)}
+          >
+            <FileCopyIcon />
+          </IconButton>
           {quote.error ? (
             <ErrorMessage id="error">{quote.error}</ErrorMessage>
           ) : (
@@ -136,6 +150,18 @@ const HomePage = () => {
       setQuote({ quote: '', author: '', error: 'Failed to fetch new quote' });
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function copyToClipboard(text: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+      alert('Quote copied!');
+      console.log('Quote copied to clipboard!');
+      // You can add a toast notification or other visual feedback here
+    } catch (err) {
+      console.error('Failed to copy quote: ', err);
+      // Handle error (e.g., show error message to the user)
     }
   }
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -114,8 +114,10 @@ const HomePage = () => {
           ) : (
             <>
               <Tagline>Your daily dose of inspiration.</Tagline>
-              <div>
-                <QuoteText id="quote">&ldquo;{quote.quote}&rdquo;</QuoteText>
+              <Box
+                sx={{
+                  position: 'relative'
+                }}>
                 <IconButton
                   size="small"
                   sx={{
@@ -127,9 +129,10 @@ const HomePage = () => {
                   onClick={() => copyToClipboard(`${quote.quote} - ${quote.author}`)}
                   data-testid="copy-quote-btn"
                 >
-                  <FileCopyIcon />
+                  <FileCopyIcon fontSize="small" />
                 </IconButton>
-              </div>
+                <QuoteText id="quote">&ldquo;{quote.quote}&rdquo;</QuoteText>
+              </Box>
               <AuthorText id="author">- {quote.author}</AuthorText>
               <NewQuoteButton onClick={() => fetchNewQuote()} disabled={loading}>
                 New Quote

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -109,7 +109,6 @@ const HomePage = () => {
       </Head>
       <MainContainer>
         <QuoteContainer>
-          </IconButton>
           {quote.error ? (
             <ErrorMessage id="error">{quote.error}</ErrorMessage>
           ) : (
@@ -128,6 +127,7 @@ const HomePage = () => {
                   data-testid="copy-quote-btn"
                 >
                   <FileCopyIcon />
+                </IconButton>
               </div>
               <AuthorText id="author">- {quote.author}</AuthorText>
               <NewQuoteButton onClick={() => fetchNewQuote()} disabled={loading}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -123,7 +123,7 @@ const HomePage = () => {
                   sx={{
                     position: 'absolute',
                     top: '-8px',
-                    right: '-20px',
+                    right: '-30px',
                     margin: 0
                   }}
                   onClick={() => copyToClipboard(`${quote.quote} - ${quote.author}`)}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -117,6 +117,7 @@ const HomePage = () => {
               margin: '8px'
             }}
             onClick={() => copyToClipboard(`${quote.quote} - ${quote.author}`)}
+            dataTestId="copy-quote-btn"
           >
             <FileCopyIcon />
           </IconButton>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -155,7 +155,7 @@ const HomePage = () => {
                     right: '-30px',
                     margin: 0
                   }}
-                  onClick={() => copyToClipboard(`${quote.quote} - ${quote.author}`)}
+                  onClick={() => copyToClipboard(`"${quote.quote}" - ${quote.author}`)}
                   data-testid="copy-quote-btn"
                 >
                   <FileCopyIcon fontSize="small" />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -117,10 +117,11 @@ const HomePage = () => {
               <div>
                 <QuoteText id="quote">&ldquo;{quote.quote}&rdquo;</QuoteText>
                 <IconButton
+                  size="small"
                   sx={{
                     position: 'absolute',
                     top: 8,
-                    right: 8,
+                    right: '-8px',
                     margin: '8px'
                   }}
                   onClick={() => copyToClipboard(`${quote.quote} - ${quote.author}`)}

--- a/tests/unit/pages/index.test.tsx
+++ b/tests/unit/pages/index.test.tsx
@@ -115,10 +115,11 @@ describe('HomePage', () => {
     });
 
     jest.runAllTimers();
-
-    const copyButton = screen.getByTestId('copy-quote-btn'); // Assuming the copy button is the only button or has a specific label/role
-    fireEvent.click(copyButton);
-
-    expect(writeTextMock).toHaveBeenCalledWith(`"${mockQuote.quote}" - ${mockQuote.author}`);
+    await waitFor(() => {
+      const copyButton = screen.getByTestId('copy-quote-btn'); // Assuming the copy button is the only button or has a specific label/role
+      fireEvent.click(copyButton);
+  
+      expect(writeTextMock).toHaveBeenCalledWith(`"${mockQuote.quote}" - ${mockQuote.author}`);
+    });
   });
 });

--- a/tests/unit/pages/index.test.tsx
+++ b/tests/unit/pages/index.test.tsx
@@ -114,9 +114,11 @@ describe('HomePage', () => {
       render(<HomePage />);
     });
 
+    jest.runAllTimers();
+
     const copyButton = screen.getByTestId('copy-quote-btn'); // Assuming the copy button is the only button or has a specific label/role
     fireEvent.click(copyButton);
 
-    expect(writeTextMock).toHaveBeenCalledWith(`${mockQuote.quote} - ${mockQuote.author}`);
+    expect(writeTextMock).toHaveBeenCalledWith(`"${mockQuote.quote}" - ${mockQuote.author}`);
   });
 });

--- a/tests/unit/pages/index.test.tsx
+++ b/tests/unit/pages/index.test.tsx
@@ -103,9 +103,9 @@ describe('HomePage', () => {
       render(<HomePage />);
     });
 
-    const copyButton = screen.getByRole('button'); // Assuming the copy button is the only button or has a specific label/role
+    const copyButton = screen.getByTestId('copy-quote-btn'); // Assuming the copy button is the only button or has a specific label/role
     fireEvent.click(copyButton);
 
-    expect(writeTextMock).toHaveBeenCalledWith('expected quote text');
+    expect(writeTextMock).toHaveBeenCalledWith(`${mockQuote.quote} - ${mockQuote.author}`);
   });
 });

--- a/tests/unit/pages/index.test.tsx
+++ b/tests/unit/pages/index.test.tsx
@@ -32,9 +32,8 @@ describe('HomePage', () => {
         writeText: jest.fn()
       }
     });
-
     writeTextMock = jest.spyOn(navigator.clipboard, 'writeText');
-      
+    window.alert = jest.fn();
     jest.useFakeTimers();
   });
 

--- a/tests/unit/pages/index.test.tsx
+++ b/tests/unit/pages/index.test.tsx
@@ -1,5 +1,5 @@
 import {act} from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import HomePage from '../../../pages/index';
 
@@ -70,5 +70,26 @@ describe('HomePage', () => {
     await waitFor(() => {
       expect(screen.getByText('Failed to fetch quote')).toBeInTheDocument();
     });
+  });
+
+  it('copies quote to clipboard on button click', async () => {
+    const mockQuote = { quote: 'Test Quote', author: 'Test Author' };
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockQuote),
+      })
+    ) as jest.Mock;
+
+    const writeTextMock = jest.spyOn(navigator.clipboard, 'writeText');
+
+    await act(async () => {
+      render(<HomePage />);
+    });
+
+    const copyButton = screen.getByRole('button'); // Assuming the copy button is the only button or has a specific label/role
+    fireEvent.click(copyButton);
+
+    expect(writeTextMock).toHaveBeenCalledWith(mockQuote.quote);
   });
 });

--- a/tests/unit/pages/index.test.tsx
+++ b/tests/unit/pages/index.test.tsx
@@ -22,6 +22,24 @@ Object.defineProperty(window, 'matchMedia', {
 });
 
 describe('HomePage', () => {
+  let writeTextMock: jest.Mock;
+
+  beforeAll(() => {
+    // Mock the navigator.clipboard object
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: jest.fn()
+      }
+    });
+
+    writeTextMock = jest.spyOn(navigator.clipboard, 'writeText');
+  });
+
+  afterAll(() => {
+    // Restore the mock
+    writeTextMock.mockRestore();
+  });
+  
   it('renders loading state initially', () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
@@ -33,7 +51,7 @@ describe('HomePage', () => {
     expect(screen.getByText('Loading...')).toBeInTheDocument();
   });
 
-  test('fetches and displays quote', async () => {
+  it('fetches and displays quote', async () => {
     const fakeQuote = { quote: 'Test Quote', author: 'Test Author' };
 
     // Mock fetch response to include ok: true
@@ -81,8 +99,6 @@ describe('HomePage', () => {
       })
     ) as jest.Mock;
 
-    const writeTextMock = jest.spyOn(navigator.clipboard, 'writeText');
-
     await act(async () => {
       render(<HomePage />);
     });
@@ -90,6 +106,6 @@ describe('HomePage', () => {
     const copyButton = screen.getByRole('button'); // Assuming the copy button is the only button or has a specific label/role
     fireEvent.click(copyButton);
 
-    expect(writeTextMock).toHaveBeenCalledWith(mockQuote.quote);
+    expect(writeTextMock).toHaveBeenCalledWith('expected quote text');
   });
 });


### PR DESCRIPTION
This commit adds a copy button to the quote display, allowing users to easily copy the quote and author to their clipboard.

- Added a small icon button with a copy icon in the top right corner of the quote container.
- Implemented the copy functionality using the Clipboard API.
- Added a unit test to verify that the correct text is copied to the clipboard.