### PR TITLE
Add theme parameter (light/dark) to /quote.svg endpoint

### DIFF
--- a/pages/api/quote.svg.ts
+++ b/pages/api/quote.svg.ts
@@ -19,21 +19,19 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
   // Extract theme from query parameters and validate
   const themeParam = req.query.theme as string;
-  let backgroundColor: string, textColor: string;
 
-  switch (themeParam) {
-    case 'light':
-      backgroundColor = '#f0f0f0';
-      textColor = '#333';
-      break;
-    case 'dark':
-      backgroundColor = '#333';
-      textColor = '#f0f0f0';
-      break;
-    default:
-      backgroundColor = '#f0f0f0';
-      textColor = '#333';
-  }
+  const themes = {
+    light: {
+      backgroundColor: '#f0f0f0',
+      textColor: '#333'
+    },
+    dark: {
+      backgroundColor: '#333',
+      textColor: '#f0f0f0'
+    },
+  };
+
+  const { backgroundColor, textColor } = themes[themeParam] || themes.light;
 
   const svg = `
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200">

--- a/pages/api/quote.svg.ts
+++ b/pages/api/quote.svg.ts
@@ -17,13 +17,31 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const randomIndex = Math.floor(Math.random() * quotes.length);
   const { quote, author } = quotes[randomIndex];
 
+  // Extract theme from query parameters and validate
+  const themeParam = req.query.theme as string;
+  let backgroundColor: string, textColor: string;
+
+  switch (themeParam) {
+    case 'light':
+      backgroundColor = '#f0f0f0';
+      textColor = '#333';
+      break;
+    case 'dark':
+      backgroundColor = '#333';
+      textColor = '#f0f0f0';
+      break;
+    default:
+      backgroundColor = '#f0f0f0';
+      textColor = '#333';
+  }
+
   const svg = `
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200">
-       <rect fill="#f0f0f0"/>
-      <text x="20" y="40" font-family="Arial" font-size="16" fill="#333" text-anchor="start">
+       <rect fill="${backgroundColor}"/>
+      <text x="20" y="40" font-family="Arial" font-size="16" fill="${textColor}" text-anchor="start">
         <tspan x="20" dy="0">${quote}</tspan>
       </text>
-      <text x="780" y="8em" font-family="Arial" font-size="14" fill="#777" text-anchor="end">
+      <text x="780" y="8em" font-family="Arial" font-size="14" fill="${themeParam === 'dark' ? '#f0f0f0' : '#777'}" text-anchor="end">
         - ${author}
       </text>
     </svg>

--- a/tests/integration/integration.test.ts
+++ b/tests/integration/integration.test.ts
@@ -70,7 +70,7 @@ describe('Integration Tests', () => {
 });
 
 describe('GET /api/quote.svg', () => {
-  it('should return a 200 status code and an SVG image', async () => {
+  it('should return a 200 status code and an SVG image with default theme when no theme is provided', async () => {
     const { req, res } = createMocks({
       method: 'GET',
       url: '/api/quote.svg',
@@ -78,6 +78,80 @@ describe('GET /api/quote.svg', () => {
 
     await handler(req, res);
     expect(res.statusCode).toBe(200);
-    // /expect(res.headers.get('Content-Type')).toBe('image/svg+xml');
+    const svg = res._getData();
+    expect(svg).toContain('fill="#f0f0f0"'); // Default background color
+    expect(svg).toContain('fill="#333"');    // Default text color
+  });
+
+  it('should return a 200 status code and an SVG image with light theme', async () => {
+    const theme = 'light';
+    const { req, res } = createMocks({
+      method: 'GET',
+      url: `/api/quote.svg?theme=${theme}`,
+    });
+ 
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    const svg = res._getData();
+    expect(svg).toContain('fill="#f0f0f0"'); // Light background color
+    expect(svg).toContain('fill="#333"');    // Light quote text color
+    expect(svg).toContain('fill="#777"');    // Light author text color
+  });
+
+  it('should return a 200 status code and an SVG image with dark theme', async () => {
+    const theme = 'dark';
+    const { req, res } = createMocks({
+      method: 'GET',
+      url: `/api/quote.svg?theme=${theme}`,
+    });
+
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    const svg = res._getData();
+    expect(svg).toContain('fill="#333"'); // Dark background color
+    expect(svg).toContain('fill="#f0f0f0"');    // Dark quote text color
+    expect(svg).toContain('fill="#f0f0f0"');    // Dark author text color
+  });
+
+  it('should return a 200 status code and an SVG image with default theme for invalid theme', async () => {
+    const theme = 'invalid-theme';
+    const { req, res } = createMocks({
+      method: 'GET',
+      url: `/api/quote.svg?theme=${theme}`,
+    });
+
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    const svg = res._getData();
+    expect(svg).toContain('fill="#f0f0f0"'); // Default background color
+    expect(svg).toContain('fill="#333"');    // Default text color
+  });
+
+  it('should return a 200 status code and an SVG image with default theme for empty theme', async () => {
+    const theme = '';
+    const { req, res } = createMocks({
+      method: 'GET',
+      url: `/api/quote.svg?theme=${theme}`,
+    });
+
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    const svg = res._getData();
+    expect(svg).toContain('fill="#f0f0f0"'); // Default background color
+    expect(svg).toContain('fill="#333"');    // Default text color
+  });
+
+  it('should return a 200 status code and an SVG image with default theme for theme with numbers', async () => {
+    const theme = '123';
+    const { req, res } = createMocks({
+      method: 'GET',
+      url: `/api/quote.svg?theme=${theme}`,
+    });
+
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    const svg = res._getData();
+    expect(svg).toContain('fill="#f0f0f0"'); // Default background color
+    expect(svg).toContain('fill="#333"');    // Default text color
   });
 });

--- a/tests/integration/integration.test.ts
+++ b/tests/integration/integration.test.ts
@@ -1,6 +1,6 @@
 import { createMocks } from 'node-mocks-http'
-import handlerQuoteJSON from '../../pages/api/quote'; // Import your API route
-import handlerQuoteSVG from '../../pages/api/quote.svg'; // Import your API route
+import handlerQuoteJSON from '../../pages/api/quote.ts'; // Import your API route
+import handlerQuoteSVG from '../../pages/api/quote.svg.ts'; // Import your API route
 
 describe('Integration Tests', () => {
 

--- a/tests/integration/integration.test.ts
+++ b/tests/integration/integration.test.ts
@@ -1,5 +1,6 @@
 import { createMocks } from 'node-mocks-http'
-import handler from '../../pages/api/quote'; // Import your API route
+import handlerQuoteJSON from '../../pages/api/quote'; // Import your API route
+import handlerQuoteSVG from '../../pages/api/quote.svg'; // Import your API route
 
 describe('Integration Tests', () => {
 
@@ -7,151 +8,152 @@ describe('Integration Tests', () => {
     clearInterval(global.cleanupInterval);
   });
   
-  it('should return a quote', async () => {
-    const { req, res } = createMocks({
-      method: 'GET',
-      url: '/api/quote',
+  describe('GET /api/quote', () => {
+    it('should return a quote', async () => {
+      const { req, res } = createMocks({
+        method: 'GET',
+        url: '/api/quote',
+      });
+  
+      await handlerQuoteJSON(req, res);
+  
+      expect(res.statusCode).toBe(200);
+      const data = JSON.parse(res._getData());
+      expect(data).toHaveProperty('quote');
+      expect(typeof data.quote).toBe('string');
+      expect(data).toHaveProperty('author');
+      expect(typeof data.author).toBe('string');
     });
-
-    await handler(req, res);
-
-    expect(res.statusCode).toBe(200);
-    console.log(res._getData());
-    const data = JSON.parse(res._getData());
-    expect(data).toHaveProperty('quote');
-    expect(typeof data.quote).toBe('string');
-    expect(data).toHaveProperty('author');
-    expect(typeof data.author).toBe('string');
+  
+    it('should return a quote by a specific author', async () => {
+      const author = 'Steve Jobs';
+      const { req, res } = createMocks({
+        method: 'GET',
+        url: `/api/quote?author=${author}`,
+      });
+  
+      await handlerQuoteJSON(req, res);
+  
+      expect(res.statusCode).toBe(200);
+      const data = JSON.parse(res._getData());
+      expect(data).toHaveProperty('quote');
+      expect(typeof data.quote).toBe('string');
+      expect(data).toHaveProperty('author');
+      expect(data.author).toBe(author);
+    });
+  
+    it('should return 404 when author is not found', async () => {
+      const author = 'Unknown Author';
+      const { req, res } = createMocks({
+        method: 'GET',
+        url: `/api/quote?author=${author}`,
+      });
+  
+      await handlerQuoteJSON(req, res);
+  
+      expect(res.statusCode).toBe(404);
+      const data = JSON.parse(res._getData());
+      expect(data).toHaveProperty('error', `No quotes found for author: ${author}`);
+    });
+  
+    it('should return 405 for non-GET requests', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        url: '/api/quote',
+      });
+  
+      await handlerQuoteJSON(req, res);
+  
+      expect(res.statusCode).toBe(405);
+      const data = JSON.parse(res._getData());
+      expect(data).toHaveProperty('error', 'Method Not Allowed');
+    });
   });
 
-  it('should return a quote by a specific author', async () => {
-    const author = 'Steve Jobs';
-    const { req, res } = createMocks({
-      method: 'GET',
-      url: `/api/quote?author=${author}`,
+  describe('GET /api/quote.svg', () => {
+    it('should return a 200 status code and an SVG image with default theme when no theme is provided', async () => {
+      const { req, res } = createMocks({
+        method: 'GET',
+        url: '/api/quote.svg',
+      });
+  
+      await handlerQuoteSVG(req, res);
+      expect(res.statusCode).toBe(200);
+      const svg = res._getData();
+      expect(svg).toContain('fill="#f0f0f0"'); // Default background color
+      expect(svg).toContain('fill="#333"');    // Default text color
     });
-
-    await handler(req, res);
-
-    expect(res.statusCode).toBe(200);
-    const data = JSON.parse(res._getData());
-    expect(data).toHaveProperty('quote');
-    expect(typeof data.quote).toBe('string');
-    expect(data).toHaveProperty('author');
-    expect(data.author).toBe(author);
-  });
-
-  it('should return 404 when author is not found', async () => {
-    const author = 'Unknown Author';
-    const { req, res } = createMocks({
-      method: 'GET',
-      url: `/api/quote?author=${author}`,
+  
+    it('should return a 200 status code and an SVG image with light theme', async () => {
+      const theme = 'light';
+      const { req, res } = createMocks({
+        method: 'GET',
+        url: `/api/quote.svg?theme=${theme}`,
+      });
+   
+      await handlerQuoteSVG(req, res);
+      expect(res.statusCode).toBe(200);
+      const svg = res._getData();
+      expect(svg).toContain('fill="#f0f0f0"'); // Light background color
+      expect(svg).toContain('fill="#333"');    // Light quote text color
+      expect(svg).toContain('fill="#777"');    // Light author text color
     });
-
-    await handler(req, res);
-
-    expect(res.statusCode).toBe(404);
-    const data = JSON.parse(res._getData());
-    expect(data).toHaveProperty('error', `No quotes found for author: ${author}`);
-  });
-
-  it('should return 405 for non-GET requests', async () => {
-    const { req, res } = createMocks({
-      method: 'POST',
-      url: '/api/quote',
+  
+    it('should return a 200 status code and an SVG image with dark theme', async () => {
+      const theme = 'dark';
+      const { req, res } = createMocks({
+        method: 'GET',
+        url: `/api/quote.svg?theme=${theme}`,
+      });
+  
+      await handlerQuoteSVG(req, res);
+      expect(res.statusCode).toBe(200);
+      const svg = res._getData();
+      expect(svg).toContain('fill="#333"'); // Dark background color
+      expect(svg).toContain('fill="#f0f0f0"');    // Dark quote text color
+      expect(svg).toContain('fill="#f0f0f0"');    // Dark author text color
     });
-
-    await handler(req, res);
-
-    expect(res.statusCode).toBe(405);
-    const data = JSON.parse(res._getData());
-    expect(data).toHaveProperty('error', 'Method Not Allowed');
-  });
-});
-
-describe('GET /api/quote.svg', () => {
-  it('should return a 200 status code and an SVG image with default theme when no theme is provided', async () => {
-    const { req, res } = createMocks({
-      method: 'GET',
-      url: '/api/quote.svg',
+  
+    it('should return a 200 status code and an SVG image with default theme for invalid theme', async () => {
+      const theme = 'invalid-theme';
+      const { req, res } = createMocks({
+        method: 'GET',
+        url: `/api/quote.svg?theme=${theme}`,
+      });
+  
+      await handlerQuoteSVG(req, res);
+      expect(res.statusCode).toBe(200);
+      const svg = res._getData();
+      expect(svg).toContain('fill="#f0f0f0"'); // Default background color
+      expect(svg).toContain('fill="#333"');    // Default text color
     });
-
-    await handler(req, res);
-    expect(res.statusCode).toBe(200);
-    const svg = res._getData();
-    expect(svg).toContain('fill="#f0f0f0"'); // Default background color
-    expect(svg).toContain('fill="#333"');    // Default text color
-  });
-
-  it('should return a 200 status code and an SVG image with light theme', async () => {
-    const theme = 'light';
-    const { req, res } = createMocks({
-      method: 'GET',
-      url: `/api/quote.svg?theme=${theme}`,
+  
+    it('should return a 200 status code and an SVG image with default theme for empty theme', async () => {
+      const theme = '';
+      const { req, res } = createMocks({
+        method: 'GET',
+        url: `/api/quote.svg?theme=${theme}`,
+      });
+  
+      await handlerQuoteSVG(req, res);
+      expect(res.statusCode).toBe(200);
+      const svg = res._getData();
+      expect(svg).toContain('fill="#f0f0f0"'); // Default background color
+      expect(svg).toContain('fill="#333"');    // Default text color
     });
- 
-    await handler(req, res);
-    expect(res.statusCode).toBe(200);
-    const svg = res._getData();
-    expect(svg).toContain('fill="#f0f0f0"'); // Light background color
-    expect(svg).toContain('fill="#333"');    // Light quote text color
-    expect(svg).toContain('fill="#777"');    // Light author text color
-  });
-
-  it('should return a 200 status code and an SVG image with dark theme', async () => {
-    const theme = 'dark';
-    const { req, res } = createMocks({
-      method: 'GET',
-      url: `/api/quote.svg?theme=${theme}`,
+  
+    it('should return a 200 status code and an SVG image with default theme for theme with numbers', async () => {
+      const theme = '123';
+      const { req, res } = createMocks({
+        method: 'GET',
+        url: `/api/quote.svg?theme=${theme}`,
+      });
+  
+      await handlerQuoteSVG(req, res);
+      expect(res.statusCode).toBe(200);
+      const svg = res._getData();
+      expect(svg).toContain('fill="#f0f0f0"'); // Default background color
+      expect(svg).toContain('fill="#333"');    // Default text color
     });
-
-    await handler(req, res);
-    expect(res.statusCode).toBe(200);
-    const svg = res._getData();
-    expect(svg).toContain('fill="#333"'); // Dark background color
-    expect(svg).toContain('fill="#f0f0f0"');    // Dark quote text color
-    expect(svg).toContain('fill="#f0f0f0"');    // Dark author text color
-  });
-
-  it('should return a 200 status code and an SVG image with default theme for invalid theme', async () => {
-    const theme = 'invalid-theme';
-    const { req, res } = createMocks({
-      method: 'GET',
-      url: `/api/quote.svg?theme=${theme}`,
-    });
-
-    await handler(req, res);
-    expect(res.statusCode).toBe(200);
-    const svg = res._getData();
-    expect(svg).toContain('fill="#f0f0f0"'); // Default background color
-    expect(svg).toContain('fill="#333"');    // Default text color
-  });
-
-  it('should return a 200 status code and an SVG image with default theme for empty theme', async () => {
-    const theme = '';
-    const { req, res } = createMocks({
-      method: 'GET',
-      url: `/api/quote.svg?theme=${theme}`,
-    });
-
-    await handler(req, res);
-    expect(res.statusCode).toBe(200);
-    const svg = res._getData();
-    expect(svg).toContain('fill="#f0f0f0"'); // Default background color
-    expect(svg).toContain('fill="#333"');    // Default text color
-  });
-
-  it('should return a 200 status code and an SVG image with default theme for theme with numbers', async () => {
-    const theme = '123';
-    const { req, res } = createMocks({
-      method: 'GET',
-      url: `/api/quote.svg?theme=${theme}`,
-    });
-
-    await handler(req, res);
-    expect(res.statusCode).toBe(200);
-    const svg = res._getData();
-    expect(svg).toContain('fill="#f0f0f0"'); // Default background color
-    expect(svg).toContain('fill="#333"');    // Default text color
   });
 });


### PR DESCRIPTION
This change introduces a  parameter to the  endpoint, allowing users to select a "light" or "dark" theme for the generated SVG.

- Modified  to accept the  query parameter with values "light" or "dark". Any other value will result in the default theme.
- Updated the SVG generation logic to apply specific color values for the background and text based on the selected theme:
  - Light theme: background #f0f0f0, quote text #333, author text #777
  - Dark theme: background #333, quote and author text #f0f0f0
- Updated  to verify the correct behavior of the endpoint with "light", "dark", and default themes, ensuring accurate styling.