### PR TITLE
Add unit test coverage measurement to CI

### DIFF
--- a/.github/workflows/pr-main-checker.yml
+++ b/.github/workflows/pr-main-checker.yml
@@ -36,7 +36,13 @@ jobs:
       - name: Lint Check
         run: npm run lint
       - name: Run unit tests
-        run: npm run test-unit
+        run: npm run test-unit -- --coverage
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/
+          retention-days: 30
   integration-test:
     name: "Integration Tests"
     needs: [build-check]


### PR DESCRIPTION
This change modifies the CI workflow to measure unit test coverage and upload the coverage report as an artifact.

- The  file was updated to add the  flag to the Jest command for unit tests.
- A new step was added to the  job to upload the coverage report as an artifact named "coverage".

This allows users to download and inspect the detailed coverage report, providing insights into the effectiveness of the unit tests.