### PR TITLE
Add test case for missing x-forwarded-for header.

### DIFF
--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -196,4 +196,31 @@ describe('Rate Limiting', () => {
     // Second request should be rejected
     await expect(limiter.check(req, res)).rejects.toThrow('Rate limit exceeded');
   });
+  it('should allow options to be undefined', async () => {
+    const limiter = rateLimit();
+
+    const req = {
+      headers: {
+        'x-forwarded-for': '127.0.0.1',
+      },
+      socket: {
+        remoteAddress: '127.0.0.1',
+      },
+      // Add other required properties with default or mock values
+      query: {},
+      cookies: {},
+      body: {},
+      env: {},
+    } as Partial<NextApiRequest> as NextApiRequest;
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      end: jest.fn(),
+    } as unknown as NextApiResponse;
+
+    // First request should be allowed
+    await limiter.check(req, res);
+    expect(res.status).not.toHaveBeenCalledWith(429);
+    expect(res.end).not.toHaveBeenCalledWith('Rate limit exceeded');
+  });
 });

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -137,4 +137,63 @@ describe('Rate Limiting', () => {
     // Second request from IP 2 should be rejected
     await expect(limiter.check(req2, res2)).rejects.toThrow('Rate limit exceeded');
   });
+
+  it('should not apply rate limiting when IP is missing', async () => {
+    const limiter = rateLimit({
+      interval: 1000, // 1 second
+      uniqueTokenPerInterval: 1, // 1 request per second
+    });
+
+    const req = {
+      headers: {}, // Missing 'x-forwarded-for'
+      socket: {},  // Missing 'remoteAddress'
+      // Add other required properties with default or mock values
+      query: {},
+      cookies: {},
+      body: {},
+      env: {},
+    } as Partial<NextApiRequest> as NextApiRequest;
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      end: jest.fn(),
+    } as unknown as NextApiResponse;
+
+    // Request should be allowed even without an IP
+    await limiter.check(req, res);
+    expect(res.status).not.toHaveBeenCalledWith(429);
+    expect(res.end).not.toHaveBeenCalledWith('Rate limit exceeded');
+  });
+
+  it('should apply rate limiting using socket.remoteAddress when x-forwarded-for is missing', async () => {
+    const limiter = rateLimit({
+      interval: 1000, // 1 second
+      uniqueTokenPerInterval: 1, // 1 request per second
+    });
+
+    const req = {
+      headers: {}, // Missing 'x-forwarded-for'
+      socket: {
+        remoteAddress: '192.168.1.100',
+      },
+      // Add other required properties with default or mock values
+      query: {},
+      cookies: {},
+      body: {},
+      env: {},
+    } as Partial<NextApiRequest> as NextApiRequest;
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      end: jest.fn(),
+    } as unknown as NextApiResponse;
+
+    // First request should be allowed
+    await limiter.check(req, res);
+    expect(res.status).not.toHaveBeenCalledWith(429);
+    expect(res.end).not.toHaveBeenCalledWith('Rate limit exceeded');
+
+    // Second request should be rejected
+    await expect(limiter.check(req, res)).rejects.toThrow('Rate limit exceeded');
+  });
 });


### PR DESCRIPTION
This commit adds a test case to verify that the rate limiter correctly applies rate limiting when the x-forwarded-for header is missing and only req.socket.remoteAddress is available.