### PR TITLE
Add unit tests for getStoredTheme with 'light' and 'dark' values.

### DIFF
--- a/tests/unit/components/ThemeProvider.test.tsx
+++ b/tests/unit/components/ThemeProvider.test.tsx
@@ -92,6 +92,23 @@ describe('ThemeProvider', () => {
     expect(screen.getByTestId('theme')).toHaveTextContent('dark');
   });
 
+  it('should initialize with stored theme from localStorage - light theme', () => {
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: jest.fn(() => 'light'),
+      },
+      writable: true,
+    });
+
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByTestId('theme')).toHaveTextContent('light');
+  });
+
   it('should remove event listener on unmount', () => {
     const removeEventListenerMock = jest.fn();
     const addEventListenerMock = jest.fn();


### PR DESCRIPTION
This commit adds a new unit test to  to cover the  function when localStorage contains the values 'light' or 'dark'. This ensures that the theme provider correctly retrieves and applies the stored theme in these scenarios, complementing the existing test for the 'dark' theme.